### PR TITLE
Add product details page

### DIFF
--- a/components/ProductListingSection.tsx
+++ b/components/ProductListingSection.tsx
@@ -2,75 +2,18 @@
 import React from 'react';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useRouter } from 'next/router';
 import { Button } from './ui/button';
 import { Card, CardContent } from './ui/card';
 import ConsultationModal from './ConsultationModal';
-
-interface Product {
-  id: number;
-  name: string;
-  price: string;
-  condition: string;
-  description: string;
-  image: string;
-}
+import { Product, products } from '../lib/products';
 
 const ProductListingSection = () => {
   const { t } = useTranslation();
   const [selectedProduct, setSelectedProduct] = useState<Product | null>(null);
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const router = useRouter();
 
-  // Mock data simulating Google Sheets API response
-  const products: Product[] = [
-    {
-      id: 1,
-      name: "Máy khoan nha khoa cao cấp",
-      price: "15,000,000 VNĐ",
-      condition: "Còn mới 95%",
-      description: "Máy khoan nha khoa hiện đại với công nghệ tiên tiến, phù hợp cho các phòng khám nha khoa chuyên nghiệp.",
-      image: "https://images.unsplash.com/photo-1609840114035-3c981b782dfe?w=400&h=300&fit=crop"
-    },
-    {
-      id: 2,
-      name: "Ghế nha khoa điện tử",
-      price: "25,000,000 VNĐ",
-      condition: "Như mới",
-      description: "Ghế nha khoa điện tử với hệ thống điều khiển thông minh, mang lại sự thoải mái tối đa cho bệnh nhân.",
-      image: "https://images.unsplash.com/photo-1629909613654-28e377c37b09?w=400&h=300&fit=crop"
-    },
-    {
-      id: 3,
-      name: "Máy X-quang nha khoa",
-      price: "35,000,000 VNĐ",
-      condition: "Đã qua sử dụng",
-      description: "Máy X-quang nha khoa chất lượng cao, hình ảnh rõ nét, hỗ trợ chẩn đoán chính xác.",
-      image: "https://images.unsplash.com/photo-1581595220892-b0739db3ba8c?w=400&h=300&fit=crop"
-    },
-    {
-      id: 4,
-      name: "Tủ tiệt trùng Autoclave",
-      price: "8,000,000 VNĐ",
-      condition: "Tốt",
-      description: "Tủ tiệt trùng Autoclave đảm bảo vệ sinh an toàn cho các dụng cụ nha khoa.",
-      image: "https://images.unsplash.com/photo-1551601651-2a8555f1a136?w=400&h=300&fit=crop"
-    },
-    {
-      id: 5,
-      name: "Máy siêu âm làm sạch răng",
-      price: "12,000,000 VNĐ",
-      condition: "Còn mới 90%",
-      description: "Máy siêu âm làm sạch răng hiệu quả, loại bỏ cao răng và mảng bám một cách nhẹ nhàng.",
-      image: "https://images.unsplash.com/photo-1606811971618-4486d14f3f99?w=400&h=300&fit=crop"
-    },
-    {
-      id: 6,
-      name: "Đèn LED phẫu thuật",
-      price: "18,000,000 VNĐ",
-      condition: "Như mới",
-      description: "Đèn LED phẫu thuật ánh sáng trắng, độ sáng cao, không tạo bóng đổ trong quá trình điều trị.",
-      image: "https://images.unsplash.com/photo-1584982751755-d86c34bd4cbd?w=400&h=300&fit=crop"
-    }
-  ];
 
   const handleConsultationRequest = (product: Product) => {
     setSelectedProduct(product);
@@ -85,7 +28,11 @@ const ProductListingSection = () => {
         </h2>
         <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-8">
           {products.map((product) => (
-            <Card key={product.id} className="overflow-hidden hover:shadow-lg transition-shadow duration-300">
+            <Card
+              key={product.id}
+              onClick={() => router.push(`/products/${product.id}`)}
+              className="overflow-hidden hover:shadow-lg transition-shadow duration-300 cursor-pointer"
+            >
               <div className="aspect-video">
                 <img
                   src={product.image}
@@ -109,7 +56,10 @@ const ProductListingSection = () => {
                   {product.description}
                 </p>
                 <Button
-                  onClick={() => handleConsultationRequest(product)}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    handleConsultationRequest(product);
+                  }}
                   className="w-full bg-blue-500 hover:bg-blue-600 text-white"
                 >
                   {t('products.requestConsultation')}

--- a/components/ui/command.tsx
+++ b/components/ui/command.tsx
@@ -21,7 +21,7 @@ const Command = React.forwardRef<
 ))
 Command.displayName = CommandPrimitive.displayName
 
-interface CommandDialogProps extends DialogProps {}
+type CommandDialogProps = DialogProps
 
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (

--- a/components/ui/textarea.tsx
+++ b/components/ui/textarea.tsx
@@ -2,8 +2,7 @@ import * as React from "react"
 
 import { cn } from "../../lib/utils";
 
-export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {

--- a/lib/products.ts
+++ b/lib/products.ts
@@ -1,0 +1,65 @@
+export interface Product {
+  id: number;
+  name: string;
+  price: string;
+  condition: string;
+  description: string;
+  image: string;
+}
+
+export const products: Product[] = [
+  {
+    id: 1,
+    name: "Máy khoan nha khoa cao cấp",
+    price: "15,000,000 VNĐ",
+    condition: "Còn mới 95%",
+    description:
+      "Máy khoan nha khoa hiện đại với công nghệ tiên tiến, phù hợp cho các phòng khám nha khoa chuyên nghiệp.",
+    image: "https://images.unsplash.com/photo-1609840114035-3c981b782dfe?w=400&h=300&fit=crop",
+  },
+  {
+    id: 2,
+    name: "Ghế nha khoa điện tử",
+    price: "25,000,000 VNĐ",
+    condition: "Như mới",
+    description:
+      "Ghế nha khoa điện tử với hệ thống điều khiển thông minh, mang lại sự thoải mái tối đa cho bệnh nhân.",
+    image: "https://images.unsplash.com/photo-1629909613654-28e377c37b09?w=400&h=300&fit=crop",
+  },
+  {
+    id: 3,
+    name: "Máy X-quang nha khoa",
+    price: "35,000,000 VNĐ",
+    condition: "Đã qua sử dụng",
+    description:
+      "Máy X-quang nha khoa chất lượng cao, hình ảnh rõ nét, hỗ trợ chẩn đoán chính xác.",
+    image: "https://images.unsplash.com/photo-1581595220892-b0739db3ba8c?w=400&h=300&fit=crop",
+  },
+  {
+    id: 4,
+    name: "Tủ tiệt trùng Autoclave",
+    price: "8,000,000 VNĐ",
+    condition: "Tốt",
+    description:
+      "Tủ tiệt trùng Autoclave đảm bảo vệ sinh an toàn cho các dụng cụ nha khoa.",
+    image: "https://images.unsplash.com/photo-1551601651-2a8555f1a136?w=400&h=300&fit=crop",
+  },
+  {
+    id: 5,
+    name: "Máy siêu âm làm sạch răng",
+    price: "12,000,000 VNĐ",
+    condition: "Còn mới 90%",
+    description:
+      "Máy siêu âm làm sạch răng hiệu quả, loại bỏ cao răng và mảng bám một cách nhẹ nhàng.",
+    image: "https://images.unsplash.com/photo-1606811971618-4486d14f3f99?w=400&h=300&fit=crop",
+  },
+  {
+    id: 6,
+    name: "Đèn LED phẫu thuật",
+    price: "18,000,000 VNĐ",
+    condition: "Như mới",
+    description:
+      "Đèn LED phẫu thuật ánh sáng trắng, độ sáng cao, không tạo bóng đổ trong quá trình điều trị.",
+    image: "https://images.unsplash.com/photo-1584982751755-d86c34bd4cbd?w=400&h=300&fit=crop",
+  },
+];

--- a/pages/products/[id].tsx
+++ b/pages/products/[id].tsx
@@ -1,0 +1,56 @@
+import React, { useState } from "react";
+import { useRouter } from "next/router";
+import { useTranslation } from "react-i18next";
+import Header from "../../components/Header";
+import Footer from "../../components/Footer";
+import ConsultationModal from "../../components/ConsultationModal";
+import { Button } from "../../components/ui/button";
+import { products } from "../../lib/products";
+
+const ProductDetailPage = () => {
+  const router = useRouter();
+  const { id } = router.query;
+  const { t } = useTranslation();
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const product = products.find((p) => p.id === Number(id));
+
+  if (!product) {
+    return <div className="pt-20 text-center">Loading...</div>;
+  }
+
+  return (
+    <div className="min-h-screen">
+      <Header />
+      <main className="pt-20 container mx-auto px-4">
+        <div className="max-w-3xl mx-auto bg-white rounded shadow">
+          <div className="aspect-video">
+            <img src={product.image} alt={product.name} className="w-full h-full object-cover" />
+          </div>
+          <div className="p-6 space-y-4">
+            <h1 className="text-2xl font-bold">{product.name}</h1>
+            <p className="text-blue-600 text-xl font-semibold">{product.price}</p>
+            <p className="text-sm text-gray-500">
+              {t('products.condition')}: {product.condition}
+            </p>
+            <p className="text-gray-700">{product.description}</p>
+            <Button
+              onClick={() => setIsModalOpen(true)}
+              className="bg-blue-500 hover:bg-blue-600 text-white"
+            >
+              {t('products.requestConsultation')}
+            </Button>
+          </div>
+        </div>
+      </main>
+      <Footer />
+      <ConsultationModal
+        isOpen={isModalOpen}
+        onClose={() => setIsModalOpen(false)}
+        productName={product.name}
+      />
+    </div>
+  );
+};
+
+export default ProductDetailPage;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,5 +1,6 @@
 
 import type { Config } from "tailwindcss";
+import animatePlugin from "tailwindcss-animate";
 
 export default {
 	darkMode: ["class"],
@@ -96,5 +97,5 @@ export default {
 			}
 		}
 	},
-	plugins: [require("tailwindcss-animate")],
+        plugins: [animatePlugin],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- centralize product data in `lib/products.ts`
- make product cards open a new details page on click
- create dynamic `[id]` page to display product info
- fix lint errors in command, textarea and tailwind config

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6875e532bc68832b873f82e5cbc6bdf9