### PR TITLE
Add Zalo chat features

### DIFF
--- a/components/ConsultationModal.tsx
+++ b/components/ConsultationModal.tsx
@@ -65,9 +65,17 @@ const ConsultationModal = ({ isOpen, onClose, productName }: ConsultationModalPr
               className="mt-1"
             />
           </div>
-          <div className="flex gap-2 pt-4">
+          <div className="flex flex-col sm:flex-row gap-2 pt-4">
             <Button type="submit" className="flex-1 bg-blue-500 hover:bg-blue-600">
               {t('consultationForm.submit')}
+            </Button>
+            <Button
+              asChild
+              className="flex-1 bg-green-500 hover:bg-green-600 text-white"
+            >
+              <a href="https://zalo.me/0912345678" target="_blank" rel="noopener noreferrer">
+                {t('consultationForm.chatZalo')}
+              </a>
             </Button>
             <Button type="button" variant="outline" onClick={onClose} className="flex-1">
               {t('consultationForm.cancel')}

--- a/components/ZaloChatButton.tsx
+++ b/components/ZaloChatButton.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { MessageCircle } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+
+const ZALO_LINK = 'https://zalo.me/0912345678';
+
+const ZaloChatButton = () => {
+  const { t } = useTranslation();
+  return (
+    <a
+      href={ZALO_LINK}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="fixed bottom-4 right-4 z-50 flex items-center gap-2 rounded-full bg-blue-500 p-3 text-white shadow-lg hover:bg-blue-600"
+    >
+      <MessageCircle size={20} />
+      <span className="hidden sm:block">{t('consultationForm.chatZalo')}</span>
+    </a>
+  );
+};
+
+export default ZaloChatButton;

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -7,6 +7,7 @@ import { Toaster } from "../components/ui/toaster";
 import { Toaster as Sonner } from "../components/ui/sonner";
 import { TooltipProvider } from "../components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import ZaloChatButton from "../components/ZaloChatButton";
 
 function MyApp({ Component, pageProps }: AppProps) {
   // Ensure QueryClient is not recreated on every render
@@ -20,6 +21,7 @@ function MyApp({ Component, pageProps }: AppProps) {
         <Toaster />
         <Sonner />
         <Component {...pageProps} />
+        <ZaloChatButton />
       </TooltipProvider>
     </QueryClientProvider>
   );

--- a/src/i18n/config.ts
+++ b/src/i18n/config.ts
@@ -35,7 +35,8 @@ const resources = {
         name: "Họ và tên",
         phone: "Số điện thoại",
         submit: "Gửi yêu cầu",
-        cancel: "Hủy"
+        cancel: "Hủy",
+        chatZalo: "Chat qua Zalo"
       },
       language: {
         vietnamese: "Tiếng Việt",
@@ -75,7 +76,8 @@ const resources = {
         name: "Full Name",
         phone: "Phone Number",
         submit: "Submit Request",
-        cancel: "Cancel"
+        cancel: "Cancel",
+        chatZalo: "Chat on Zalo"
       },
       language: {
         vietnamese: "Tiếng Việt",


### PR DESCRIPTION
## Summary
- add Zalo chat floating button component
- expose the chat button globally in `_app`
- allow chatting via Zalo from the consultation modal
- provide translations for the new chat option

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6876706c3950832b9286d63dcdca9e71